### PR TITLE
25 add unfollow button closes #25

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,9 +1,6 @@
 class FavoritesController < ApplicationController
-  def new
-  end
-
   def create
-    current_user.service.favorite(params[:tweet])
+    current_user.service.favorite(params[:uid])
     redirect_to current_user
   end
 end

--- a/app/controllers/retweets_controller.rb
+++ b/app/controllers/retweets_controller.rb
@@ -1,9 +1,6 @@
 class RetweetsController < ApplicationController
-  def new
-  end
-
   def create
-    current_user.service.retweet(params[:tweet])
+    current_user.service.retweet(params[:uid])
     redirect_to current_user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,4 +2,9 @@ class UsersController < ApplicationController
   def show
     @user = UserPresenter.new(current_user)
   end
+
+  def unfollow
+    current_user.service.unfollow(params[:screen_name])
+    redirect_to current_user
+  end
 end

--- a/app/services/twitter_service.rb
+++ b/app/services/twitter_service.rb
@@ -37,4 +37,8 @@ class TwitterService
   def following
     twitter_user.friends_count
   end
+
+  def unfollow(screen_name)
+    connection.unfollow(screen_name)
+  end
 end

--- a/app/views/favorites/_new.html.erb
+++ b/app/views/favorites/_new.html.erb
@@ -1,4 +1,0 @@
-<%= bootstrap_form_tag url: "/favorites" do |f| %>
-  <%= f.hidden_field :tweet, value: tweet.id %>
-  <%= submit_tag "Favorite" %>
-<% end %>

--- a/app/views/retweets/_new.html.erb
+++ b/app/views/retweets/_new.html.erb
@@ -1,6 +1,0 @@
-<div class="retweet-<%= tweet.id %>">
-  <%= bootstrap_form_tag url: "/retweets" do |f| %>
-    <%= f.hidden_field :tweet, value: tweet.id %>
-    <%= submit_tag "Retweet" %>
-  <% end %>
-</div>

--- a/app/views/tweets/_tweet.html.erb
+++ b/app/views/tweets/_tweet.html.erb
@@ -1,15 +1,28 @@
 <div class="well col-md-12">
-  <div class="col-md-2"><%= image_tag tweet.user[:profile_image_url] %></div>
+  <div class="col-md-2">
+    <%= image_tag tweet.user[:profile_image_url] %>
+    <br>
+    <div class="unfollow-<%= tweet.id %>">
+      <% unless tweet.user[:id] == current_user.uid.to_i %>
+        <%= button_to "Unfollow", unfollow_path(tweet.user), class: "btn
+        btn-sm" %>
+      <% end %>
+    </div>
+  </div>
   <div class="col-md-10"><strong><%= tweet.user[:name] %></strong> @<%= tweet.user[:screen_name] %><br>
-    <%= tweet.text %><br>
-    <% unless tweet.retweeted? || tweet.user[:id] == current_user.uid.to_i %>
-      <%= render partial: "/retweets/new", locals: {tweet: tweet} %>
-    <% end %>
-    <%= tweet.retweet_count %>
+    <%= tweet.text %>
+    <div class="retweet-<%= tweet.id %>">
+      <% unless tweet.retweeted? || tweet.user[:id] == current_user.uid.to_i %>
+          <%= button_to "Retweet", retweets_path(uid: tweet.id), class: "btn
+          btn-sm" %>
+      <% end %>
+    </div>
+    Retweets: <%= tweet.retweet_count %>
     <% unless tweet.favorited? %>
-      <%= render partial: "/favorites/new", locals: {tweet: tweet} %>
+        <%= button_to "Favorite", favorites_path(uid: tweet.id), class: "btn
+        btn-sm" %>
     <% end %>
-    <%= tweet.favorite_count %>
+    Favorites: <%= tweet.favorite_count %>
   </div>
 </div>
 <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   resources :tweets, only: [:new, :create]
   resources :favorites, only: [:new, :create]
   resources :retweets, only: [:new, :create]
+  post "unfollow", as: :unfollow, to: "users#unfollow"
 end

--- a/spec/features/user_can_unfollow_another_user_spec.rb
+++ b/spec/features/user_can_unfollow_another_user_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "user can unfollow another user", type: :feature, vcr: true do
+  describe "from within the app" do
+    it "by clicking the unfollow button" do
+      visit "/"
+      click_on "Login"
+
+      current_user = User.last
+      following_count = UserPresenter.new(current_user).following
+      tweets = current_user.service.tweets
+      @tweet = tweets.find { |tweet| tweet.id == 659215168258183168 }
+      within(".unfollow-#{@tweet.id}") do
+        click_on "Unfollow"
+        VCR.use_cassette("/user_can_unfollow_a_user after") do
+          @new_following_count = UserPresenter.new(current_user).following
+        end
+        expect(@new_following_count).to eq(following_count - 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR focuses on adding unfollow functionality and refactoring two different troublesome routes.

The routes that used to be supported were the new actions in both favorites and retweets. Before this both of them used a new form that had hidden fields. Now we use the more secure button to method.
